### PR TITLE
(minor) Adding Observable and operator for stream

### DIFF
--- a/.github/scripts/run-testing.sh
+++ b/.github/scripts/run-testing.sh
@@ -11,11 +11,11 @@ COVERAGE_RULE=$([[ "$WITH_COVERAGE" == 'True' ]] && echo "--codeCoverage" || ech
 
 echo "Running Unit Testing"
 if [[ "$RUN_ALL" == "True" ]]; then
-  npm run affected:test -- "$COVERAGE_RULE" --all --parallel --maxParallel=2
+  npm run affected:test -- "$COVERAGE_RULE" --all --parallel --maxParallel=2 --skip-nx-cache
 else
   AFFECTED=$(node node_modules/.bin/nx affected:libs --plain --base="$BASE")
   echo "Will test: $AFFECTED"
-  npm run affected:test -- --base="$BASE" "$COVERAGE_RULE" --parallel --maxParallel=2
+  npm run affected:test -- --base="$BASE" "$COVERAGE_RULE" --parallel --maxParallel=2 --skip-nx-cache
 fi
 echo "Unit Testing Complete"
 if [[ "$WITH_COVERAGE" == "True" ]]; then

--- a/libs/rxjs/utility/CHANGELOG.md
+++ b/libs/rxjs/utility/CHANGELOG.md
@@ -2,8 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
+to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `fromReadableStream` takes a [ReadableStream](https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream) and
+  converts it into a Observable source
+- `toWritableStream` operator takes a [WritableStream](https://developer.mozilla.org/en-US/docs/Web/API/WritableStream)
+  and emits the value from the source Observable to it.
 
 ## [3.0.0] - 2020-12-21
 
@@ -20,7 +29,8 @@ coverage that provided various bug fixes.
 
 ### Changed
 
-- Package is now published under `@rxjs-ninja/rxjs-utility` (this also includes previous version for migration from `@tinynodes/rxjs-utility`)
+- Package is now published under `@rxjs-ninja/rxjs-utility` (this also includes previous version for migration
+  from `@tinynodes/rxjs-utility`)
 - Documentation updates
 
 ## [2.1.1] - 2020-11-20
@@ -45,7 +55,8 @@ coverage that provided various bug fixes.
 ### Added
 
 - `tapIf` operator that fires a callback only when the predicate function is `true`
-- `mapIfSource` operator that takes a predicate function, and two methods to return a value based on the predicate being `true` or `false`.
+- `mapIfSource` operator that takes a predicate function, and two methods to return a value based on the predicate
+  being `true` or `false`.
 
 ## [1.3.1] - 2020-05-24
 
@@ -83,5 +94,6 @@ Initial release of library
 
 ### Added
 
-- `debounceWithQuery` - Operator that takes a string Observable, debouncing the value before passing to a callback that returns an Observable
+- `debounceWithQuery` - Operator that takes a string Observable, debouncing the value before passing to a callback that
+  returns an Observable
 - `startWithTap` - Operator that fires a callback only on the first emission from an Observable subscription

--- a/libs/rxjs/utility/src/index.ts
+++ b/libs/rxjs/utility/src/index.ts
@@ -12,4 +12,6 @@ export { mapIfSource } from './lib/map-if-source';
 export { tapIf } from './lib/tap-if';
 export { tapOnFirstEmit } from './lib/tap-on-first-emit';
 export { tapOnSubscribe } from './lib/tap-on-subscribe';
+export { toWritableStream } from './lib/to-writable-stream';
+export { fromReadableStream } from './lib/from-readable-stream';
 export { fromFetchWithProgress as ɵfromFetchWithProgress } from './lib/from-fetch-with-progress';

--- a/libs/rxjs/utility/src/lib/from-readable-stream.spec.ts
+++ b/libs/rxjs/utility/src/lib/from-readable-stream.spec.ts
@@ -1,0 +1,39 @@
+import { observe } from 'rxjs-marbles/jest';
+import { fromReadableStream } from '@rxjs-ninja/rxjs-utility';
+import { reduce, tap } from 'rxjs/operators';
+
+describe('fromReadableSource', () => {
+  beforeAll(() => {
+    (global as any).WritableStream = jest.fn().mockImplementation((input) => {
+      return {
+        enqueue: (value: any) => input.write(value),
+        close: () => input.close(),
+      };
+    });
+    (global as any).ReadableSteam = jest.fn().mockImplementation(() => {
+      return {
+        cancel: () => Promise.resolve(),
+        pipeTo: (writer: any) => {
+          for (let i = 0; i < 100; i++) {
+            writer.enqueue(i);
+          }
+          writer.close();
+
+          return Promise.resolve();
+        },
+      };
+    });
+  });
+
+  it(
+    'should create an Observable from a readable source',
+    observe(() => {
+      const stream = (global as any).ReadableSteam();
+
+      return fromReadableStream<number>(stream as any).pipe(
+        reduce((a, b) => a + b, 0),
+        tap((val) => expect(val).toBe(4950)),
+      );
+    }),
+  );
+});

--- a/libs/rxjs/utility/src/lib/from-readable-stream.ts
+++ b/libs/rxjs/utility/src/lib/from-readable-stream.ts
@@ -1,0 +1,61 @@
+/**
+ * @packageDocumentation
+ * @module Utility
+ */
+import { Observable } from 'rxjs';
+
+/**
+ * Creates an Observable source from a
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream|ReadableStream} source
+ *
+ * @category Streams
+ *
+ * @param stream The `ReadableStream` to subscribe to
+ * @param signal Optional {@link https://developer.mozilla.org/en-US/docs/Web/API/AbortSignal|AbortSignal} to provide
+ *   to the underlying stream
+ * @param queueStrategy Optional strategy for backpressure queueing
+ *
+ * @example Create a ReadableStream of `0` to `100` and convert to an Observable
+ * ```ts
+ * const stream = new ReadableStream({
+ *   start: (controller) => {
+ *    for (let i = 0; i <100; i++) {
+ *      controller.enqueue(i)
+ *    }
+ *    controller.close();
+ *   }
+ * });
+ *
+ * fromReadableStream(stream).pipe(reduce((a, b) => a + b)).subscribe();
+ * ```
+ * Output: `4950`
+ *
+ * @returns Observable that emits from a `ReadableStream` source
+ */
+export function fromReadableStream<T extends unknown>(
+  stream: ReadableStream<T>,
+  signal?: AbortSignal,
+  queueStrategy?: QueuingStrategy,
+): Observable<T> {
+  return new Observable<T>((subscriber) => {
+    stream
+      .pipeTo(
+        new WritableStream<T>(
+          {
+            write: (value) => subscriber.next(value),
+            abort: (error) => subscriber.error(error),
+            close: () => {
+              if (!subscriber.closed) {
+                subscriber.complete();
+              }
+            },
+          },
+          queueStrategy,
+        ),
+        { signal },
+      )
+      .then(() => subscriber.complete());
+
+    return () => !stream.locked && stream.cancel();
+  });
+}

--- a/libs/rxjs/utility/src/lib/from-readable-stream.ts
+++ b/libs/rxjs/utility/src/lib/from-readable-stream.ts
@@ -54,7 +54,7 @@ export function fromReadableStream<T extends unknown>(
         ),
         { signal },
       )
-      .then(() => subscriber.complete());
+      .then(() => !subscriber.closed && subscriber.complete());
 
     return () => !stream.locked && stream.cancel();
   });

--- a/libs/rxjs/utility/src/lib/to-writable-stream.spec.ts
+++ b/libs/rxjs/utility/src/lib/to-writable-stream.spec.ts
@@ -1,0 +1,38 @@
+import { observe } from 'rxjs-marbles/jest';
+import { fromReadableStream, toWritableStream } from '@rxjs-ninja/rxjs-utility';
+import { finalize, reduce, tap } from 'rxjs/operators';
+import { from } from 'rxjs';
+
+describe('fromReadableSource', () => {
+  let inner: any;
+
+  beforeAll(() => {
+    inner = {
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      write: () => {},
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      abort: () => {},
+      // eslint-disable-next-line @typescript-eslint/no-empty-function
+      close: () => {},
+    };
+
+    (global as any).WritableStream = jest.fn(() => ({
+      getWriter: () => inner,
+    }));
+  });
+
+  it(
+    'should create an Observable from a readable source',
+    observe(() => {
+      const stream = (global as any).WritableStream();
+      spyOn(inner, 'write');
+
+      return from([1, 2, 3, 4, 5]).pipe(
+        toWritableStream(stream),
+        finalize(() => {
+          expect(inner.write).toHaveBeenCalledTimes(5);
+        }),
+      );
+    }),
+  );
+});

--- a/libs/rxjs/utility/src/lib/to-writable-stream.spec.ts
+++ b/libs/rxjs/utility/src/lib/to-writable-stream.spec.ts
@@ -7,13 +7,27 @@ describe('toWritableStream', () => {
   let inner: any;
 
   beforeAll(() => {
+    let isClosed = false;
+    let interval: any;
+
     inner = {
+      get closed() {
+        return new Promise((resolve) => {
+          interval = setInterval(() => {
+            if (isClosed) {
+              resolve();
+            }
+          }, 1000);
+        }).finally(() => clearInterval(interval));
+      },
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       write: () => {},
       // eslint-disable-next-line @typescript-eslint/no-empty-function
       abort: () => {},
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      close: () => {},
+      close: () => {
+        isClosed = true;
+      },
     };
 
     (global as any).WritableStream = jest.fn(() => ({

--- a/libs/rxjs/utility/src/lib/to-writable-stream.ts
+++ b/libs/rxjs/utility/src/lib/to-writable-stream.ts
@@ -1,0 +1,45 @@
+/**
+ * @packageDocumentation
+ * @module Utility
+ */
+import { MonoTypeOperatorFunction, throwError } from 'rxjs';
+import { catchError, finalize, switchMap, tap } from 'rxjs/operators';
+
+/**
+ * Returns the source Observable, emitting it through the passed
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/WritableStream|WritableStream} source, with error
+ * and subscription end handing
+ *
+ * @category Streams
+ *
+ * @param stream The writable stream to emit to
+ *
+ * @example Write an array of Observable values to a `WritableStream`
+ * ```ts
+ * let result = ''
+ * const stream = new WritableStream({
+ *   write: (chunk) => result += chunk,
+ *   close: () => console.log(result)
+ * });
+ *
+ * const input = ['Hello', ' ', 'RxJS', ' ', 'Ninja'];
+ * from(input).pipe(toWritableStream(stream)).subscribe();
+ * ```
+ * Output: `Hello RxJS Ninja`
+ *
+ * @returns Observable that emits the source observable after performing a write to the WritableStream
+ */
+export function toWritableStream<T extends unknown>(stream: WritableStream<T>): MonoTypeOperatorFunction<T> {
+  const writer = stream.getWriter();
+
+  return (source) =>
+    source.pipe(
+      tap((value) => writer.write(value)),
+      catchError((error) => {
+        writer.abort(error);
+        return throwError(error);
+      }),
+      finalize(() => writer.close()),
+      switchMap(() => source),
+    );
+}


### PR DESCRIPTION
### Added
- `fromReadableStream` takes a ReadableStream object in the browser and converts to a RxJS Observable
- `toWritableStream` operator takes a source Observable and puts the values into a WritableStream