### PR TITLE
(minor) New operators and some internals and doc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,14 @@ of([10, 4, 7, 3, 1, 29, 5])
 |
 [Changelog](https://github.com/rxjs-ninja/rxjs-ninja/blob/main/libs/rxjs/boolean/CHANGELOG.md)
 
-`@rxjs-ninja/rxjs-boolean` provides operators for querying, filtering and modifying boolean values, and Observable for
-generating boolean emitters.
+`@rxjs-ninja/rxjs-boolean` provides operators for querying, filtering and modifying boolean values, and Observable for generating boolean emitters.
+
+### Function and Operator categories
+
+- Create - Functions and Operators for creating Observable boolean values
+- Filter - Operators for filtering Observable sources for truthy values
+- Modify - Operators for modifying boolean values
+- Validation - Operators that provide boolean output based on checks against source values
 
 For example, you can use the `firstTruthy` or `lastTruthy` value from an array:
 

--- a/libs/rxjs/boolean/CHANGELOG.md
+++ b/libs/rxjs/boolean/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `firstFalsy` operator that takes a required predicate and returns the first falsy value to the next operator
+- `lastFalsy` operator that takes a required predicate and returns the last falsy value to the next operator
+- `filterFalsy` operator that takes a required predicate and returns only values that don't pass the predicate
+
+### Changed
+
+- Documentation updates and reorganising categories
+- Internal improvements to `fromBoolean`
+
 ## [3.0.0] - 2020-12-21
 
 ### Updated

--- a/libs/rxjs/boolean/README.md
+++ b/libs/rxjs/boolean/README.md
@@ -12,6 +12,13 @@
 
 `@rxjs-ninja/rxjs-boolean` provides operators for querying, filtering and modifying boolean values, and Observable for generating boolean emitters.
 
+### Function and Operator categories
+
+- Create - Functions and Operators for creating Observable boolean values
+- Filter - Operators for filtering Observable sources for truthy values
+- Modify - Operators for modifying boolean values
+- Validation - Operators that provide boolean output based on checks against source values
+
 For example, you can use the `firstTruthy` or `lastTruthy` value from an array:
 
 ```ts

--- a/libs/rxjs/boolean/src/index.ts
+++ b/libs/rxjs/boolean/src/index.ts
@@ -7,10 +7,13 @@
  * @ignore
  */
 /* istanbul ignore file */
+export { firstFalsy } from './lib/first-falsy';
 export { firstTruthy } from './lib/first-truthy';
+export { filterFalsy } from './lib/filter-falsy';
 export { filterTruthy } from './lib/filter-truthy';
 export { flip } from './lib/flip';
 export { fromBoolean } from './lib/from-boolean';
+export { lastFalsy } from './lib/last-falsy';
 export { lastTruthy } from './lib/last-truthy';
 export { luhnCheck } from './lib/luhn-check';
 export { toBoolean } from './lib/to-boolean';

--- a/libs/rxjs/boolean/src/lib/filter-falsy.spec.ts
+++ b/libs/rxjs/boolean/src/lib/filter-falsy.spec.ts
@@ -1,0 +1,16 @@
+import { filterFalsy } from '@rxjs-ninja/rxjs-boolean';
+import { marbles } from 'rxjs-marbles/jest';
+
+describe('filterFalsy', () => {
+  it(
+    'should filter a source of truthy values with predicate',
+    marbles((m) => {
+      const predicate = (num: number): boolean => num % 2 === 0;
+      const input = m.hot('-a-b-c-d-e-|', { a: 0, b: 1, c: 2, d: 3, e: 4 });
+      const subs = '^----------!';
+      const expected = m.cold('---b---d---|', { b: 1, d: 3 });
+      m.expect(input.pipe(filterFalsy(predicate))).toBeObservable(expected);
+      m.expect(input).toHaveSubscriptions(subs);
+    }),
+  );
+});

--- a/libs/rxjs/boolean/src/lib/filter-falsy.ts
+++ b/libs/rxjs/boolean/src/lib/filter-falsy.ts
@@ -1,0 +1,31 @@
+/**
+ * @packageDocumentation
+ * @module Boolean
+ */
+import { MonoTypeOperatorFunction } from 'rxjs';
+import { filter } from 'rxjs/operators';
+import { PredicateFn } from '../types/boolean';
+
+/**
+ * Returns an Observable that emits only values from a source that does not pass the passed predicate
+ *
+ * @category Filter
+ *
+ * @typeParam T Type of the value from the source Observable
+ *
+ * @param predicate Optional [[PredicateFn]] function to compared the values against
+ *
+ * @example
+ * Returns a number value from a source where the number does not pass the predicate
+ * ```ts
+ * const mod2 = (num: number) => num % 2 === 0
+ * const input = [0, 1, 2, 3, 4, 5, 6];
+ * from(input).pipe(filterFalsy(mod2)).subscribe();
+ * ```
+ * Output: `1, 3, 5`
+ *
+ * @returns Observable that emits only values that don't pass the [[PredicateFn]]
+ */
+export function filterFalsy<T extends unknown>(predicate: PredicateFn<T>): MonoTypeOperatorFunction<T> {
+  return (source) => source.pipe(filter((value) => !predicate(value)));
+}

--- a/libs/rxjs/boolean/src/lib/filter-truthy.ts
+++ b/libs/rxjs/boolean/src/lib/filter-truthy.ts
@@ -2,16 +2,17 @@
  * @packageDocumentation
  * @module Boolean
  */
-import { MonoTypeOperatorFunction, Observable } from 'rxjs';
+import { MonoTypeOperatorFunction } from 'rxjs';
 import { filter } from 'rxjs/operators';
 import { PredicateFn } from '../types/boolean';
 
 /**
- * Returns an Observable that emits only truthy values from a source
+ * Returns an Observable that emits only truthy values from a source, with optional function to further filter the truthy
+ * values with a stricter check
  *
- * @category Boolean Filters
+ * @category Filter
  *
- * @typeParam T The value contained in the source Observable
+ * @typeParam T Type of the value from the source Observable
  *
  * @param predicate Optional [[PredicateFn]] function to compared the values against
  *
@@ -51,6 +52,5 @@ import { PredicateFn } from '../types/boolean';
  * @returns Observable that emits only truthy values or values that pass the optional [[PredicateFn]]
  */
 export function filterTruthy<T extends unknown>(predicate?: PredicateFn<T>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    source.pipe(filter((value) => (predicate ? Boolean(value) && predicate(value) : Boolean(value))));
+  return (source) => source.pipe(filter((value) => (predicate ? Boolean(value) && predicate(value) : Boolean(value))));
 }

--- a/libs/rxjs/boolean/src/lib/first-falsy.spec.ts
+++ b/libs/rxjs/boolean/src/lib/first-falsy.spec.ts
@@ -1,0 +1,15 @@
+import { firstFalsy } from '@rxjs-ninja/rxjs-boolean';
+import { marbles } from 'rxjs-marbles/jest';
+
+describe('firstFalsy', () => {
+  it(
+    'filter the first falsy value with predicate',
+    marbles((m) => {
+      const input = m.hot('-a-b-c-d-e-', { a: 2, b: 4, c: 5, d: 6, e: 7 });
+      const subs = '^----!';
+      const expected = m.cold('-----(c|)', { c: 5 });
+      m.expect(input.pipe(firstFalsy((num: number) => num % 2 === 0))).toBeObservable(expected);
+      m.expect(input).toHaveSubscriptions(subs);
+    }),
+  );
+});

--- a/libs/rxjs/boolean/src/lib/first-falsy.ts
+++ b/libs/rxjs/boolean/src/lib/first-falsy.ts
@@ -1,0 +1,34 @@
+/**
+ * @packageDocumentation
+ * @module Boolean
+ */
+import { MonoTypeOperatorFunction } from 'rxjs';
+import { filter, first } from 'rxjs/operators';
+import { PredicateFn } from '../types/boolean';
+
+/**
+ * Returns an Observable that emits the first value that does not pass the predicate
+ *
+ * @category Filter
+ *
+ * @typeParam T Type of the value from the source Observable
+ *
+ * @param predicate Optional [[PredicateFn]] function to compared the values against
+ *
+ * @example
+ * Return the first falsy number for the predicate
+ * ```ts
+ * const input = [0, 1, 2, 3, 4, 5, 6];
+ * from(input).pipe(firstTruthy((value) => value % 2 === 0)).subscribe();
+ * ```
+ * Output: `1`
+ *
+ * @returns Observable that emits the first values to not pass the predicate
+ */
+export function firstFalsy<T extends unknown>(predicate: PredicateFn<T>): MonoTypeOperatorFunction<T> {
+  return (source) =>
+    source.pipe(
+      filter((value) => !predicate(value)),
+      first(),
+    );
+}

--- a/libs/rxjs/boolean/src/lib/first-truthy.ts
+++ b/libs/rxjs/boolean/src/lib/first-truthy.ts
@@ -2,16 +2,17 @@
  * @packageDocumentation
  * @module Boolean
  */
-import { MonoTypeOperatorFunction, Observable } from 'rxjs';
+import { MonoTypeOperatorFunction } from 'rxjs';
 import { filter, first } from 'rxjs/operators';
 import { PredicateFn } from '../types/boolean';
 
 /**
- * Returns an Observable that emits the first truthy value from a source.
+ * Returns an Observable that emits the first truthy value from a source, with optional function to further filter the
+ * truthy values with a stricter check
  *
- * @category Boolean Filters
+ * @category Filter
  *
- * @typeParam T The value contained in the source Observable
+ * @typeParam T Type of the value from the source Observable
  *
  * @param predicate Optional [[PredicateFn]] function to compared the values against
  *
@@ -42,7 +43,7 @@ import { PredicateFn } from '../types/boolean';
  * @returns Observable that emits the first truthy value
  */
 export function firstTruthy<T extends unknown>(predicate?: PredicateFn<T>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
+  return (source) =>
     source.pipe(
       filter((value) => (predicate ? Boolean(value) && predicate(value) : Boolean(value))),
       first(),

--- a/libs/rxjs/boolean/src/lib/flip.ts
+++ b/libs/rxjs/boolean/src/lib/flip.ts
@@ -2,13 +2,13 @@
  * @packageDocumentation
  * @module Boolean
  */
-import { MonoTypeOperatorFunction, Observable } from 'rxjs';
+import { MonoTypeOperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 /**
  * Returns an Observable that emits a flipped boolean value from the source value
  *
- * @category Boolean Modify
+ * @category Modify
  *
  * @example
  * Returns flipped boolean values
@@ -21,5 +21,5 @@ import { map } from 'rxjs/operators';
  * @returns Observable that emits a boolean where the source Observable value have been flipped
  */
 export function flip(): MonoTypeOperatorFunction<boolean> {
-  return (source: Observable<boolean>) => source.pipe(map((value) => !value));
+  return (source) => source.pipe(map((value) => !value));
 }

--- a/libs/rxjs/boolean/src/lib/from-boolean.spec.ts
+++ b/libs/rxjs/boolean/src/lib/from-boolean.spec.ts
@@ -1,4 +1,4 @@
-import { filter, map, reduce, tap } from 'rxjs/operators';
+import { catchError, filter, map, reduce, tap } from 'rxjs/operators';
 import { fromBoolean } from '@rxjs-ninja/rxjs-boolean';
 import { observe } from 'rxjs-marbles/jest';
 import { of } from 'rxjs';
@@ -20,6 +20,19 @@ describe('fromBoolean', () => {
       fromBoolean(Promise.resolve(false)).pipe(
         map((val) => !val),
         tap((value) => expect(value).toBeTruthy()),
+      ),
+    ),
+  );
+
+  it(
+    'should create an Error from a failed promise',
+    observe(() =>
+      fromBoolean(Promise.reject('RxJS Ninja')).pipe(
+        map((val) => !val),
+        catchError((error) => {
+          expect(error).toBe('RxJS Ninja');
+          return of(true);
+        }),
       ),
     ),
   );

--- a/libs/rxjs/boolean/src/lib/from-boolean.ts
+++ b/libs/rxjs/boolean/src/lib/from-boolean.ts
@@ -9,9 +9,10 @@ import { isPromise } from 'rxjs/internal-compatibility';
 /**
  * Returns an Observable that emits boolean values from passed source of values.
  *
- * @category Boolean Observables
+ * @category Create
  *
- * @typeParam T The type or types to be used to create boolean values from
+ * @typeParam T Type of the value from the source Observable
+ * @typeParam A Input types accepted to convert to boolean
  *
  * @param args Input values to create the Observable source from
  *
@@ -32,8 +33,8 @@ import { isPromise } from 'rxjs/internal-compatibility';
  * @returns Observable that emits boolean values of the source value
 
  */
-export function fromBoolean<T extends ObservableInput<unknown> | PromiseLike<unknown> | unknown | unknown[]>(
-  ...args: T[]
+export function fromBoolean<T extends unknown, A extends ObservableInput<T> | PromiseLike<T> | T | T[]>(
+  ...args: A[]
 ): Observable<boolean> {
   if (isObservable(args[0])) {
     return (args[0] as Observable<T>).pipe(map(Boolean));
@@ -41,6 +42,7 @@ export function fromBoolean<T extends ObservableInput<unknown> | PromiseLike<unk
     return new Observable<boolean>((subscriber: Subscriber<unknown>): void => {
       (args[0] as Promise<T>).then(
         (value) => {
+          /* istanbul ignore next-line */
           if (!subscriber.closed) {
             subscriber.next(value);
             subscriber.complete();
@@ -50,9 +52,7 @@ export function fromBoolean<T extends ObservableInput<unknown> | PromiseLike<unk
       );
     });
   } else {
-    let value = Array.isArray(args[0]) ? (args[0] as unknown[]) : ([...args] as unknown[]);
-    value = value.map(Boolean);
-
+    const value = (Array.isArray(args[0]) ? (args[0] as T[]) : ([...args] as T[])).map(Boolean);
     return new Observable<boolean>((subscriber: Subscriber<unknown>): void => {
       for (let i = 0; i < value.length; i++) {
         subscriber.next(value[i]);

--- a/libs/rxjs/boolean/src/lib/last-falsy.spec.ts
+++ b/libs/rxjs/boolean/src/lib/last-falsy.spec.ts
@@ -1,0 +1,15 @@
+import { lastFalsy } from '@rxjs-ninja/rxjs-boolean';
+import { marbles } from 'rxjs-marbles/jest';
+
+describe('lastFalsy', () => {
+  it(
+    'should filter the last truthy item with predicate',
+    marbles((m) => {
+      const input = m.hot('-a-b-c-d-e-|', { a: 2, b: 3, c: 5, d: 6, e: 8 });
+      const subs = '^----------!';
+      const expected = m.cold('-----------(c|)', { c: 5 });
+      m.expect(input.pipe(lastFalsy((num: number) => num % 2 === 0))).toBeObservable(expected);
+      m.expect(input).toHaveSubscriptions(subs);
+    }),
+  );
+});

--- a/libs/rxjs/boolean/src/lib/last-falsy.ts
+++ b/libs/rxjs/boolean/src/lib/last-falsy.ts
@@ -1,0 +1,34 @@
+/**
+ * @packageDocumentation
+ * @module Boolean
+ */
+import { MonoTypeOperatorFunction } from 'rxjs';
+import { filter, takeLast } from 'rxjs/operators';
+import { PredicateFn } from '../types/boolean';
+
+/**
+ * Returns an Observable that emits the last value that does not pass the predicate
+ *
+ * @category Filter
+ *
+ * @typeParam T Type of the value from the source Observable
+ *
+ * @param predicate Optional [[PredicateFn]] function to compared the values against
+ *
+ * @example
+ * Return the last falsy number for the predicate
+ * ```ts
+ * const input = [0, 1, 2, 3, 4, 5, 6];
+ * from(input).pipe(lastFalsy((value) => value % 2 === 0)).subscribe();
+ * ```
+ * Output: `5`
+ *
+ * @returns Observable that emits the last values to not pass the predicate
+ */
+export function lastFalsy<T extends unknown>(predicate: PredicateFn<T>): MonoTypeOperatorFunction<T> {
+  return (source) =>
+    source.pipe(
+      filter((value) => !predicate(value)),
+      takeLast(1),
+    );
+}

--- a/libs/rxjs/boolean/src/lib/last-truthy.ts
+++ b/libs/rxjs/boolean/src/lib/last-truthy.ts
@@ -2,16 +2,17 @@
  * @packageDocumentation
  * @module Boolean
  */
-import { MonoTypeOperatorFunction, Observable } from 'rxjs';
+import { MonoTypeOperatorFunction } from 'rxjs';
 import { filter, takeLast } from 'rxjs/operators';
 import { PredicateFn } from '../types/boolean';
 
 /**
- * Returns an Observable that emits the last truthy value from a source.
+ * Returns an Observable that emits the last truthy value from a source, with optional function to further filter the
+ * truthy values with a stricter check
  *
- * @category Boolean Filters
+ * @category Filter
  *
- * @typeParam T The value contained in the source Observable
+ * @typeParam T Type of the value from the source Observable
  *
  * @param predicate Optional [[PredicateFn]] function to compared the values against
  *
@@ -42,7 +43,7 @@ import { PredicateFn } from '../types/boolean';
  * @returns Observable that emits the last truthy value
  */
 export function lastTruthy<T extends unknown>(predicate?: PredicateFn<T>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
+  return (source) =>
     source.pipe(
       filter((value) => (predicate ? Boolean(value) && predicate(value) : Boolean(value))),
       takeLast(1),

--- a/libs/rxjs/boolean/src/lib/luhn-check.ts
+++ b/libs/rxjs/boolean/src/lib/luhn-check.ts
@@ -2,16 +2,20 @@
  * @packageDocumentation
  * @module Boolean
  */
-import { Observable, OperatorFunction } from 'rxjs';
+import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { createLuhnModulus, reverseLuhnNumbers } from '../utils/luhn-check.utils';
 
 /**
- * Returns an Observable that emits a boolean value.  The source should emit a number or string that can be checked
- * with the {@link https://en.wikipedia.org/wiki/Luhn_algorithm|Luhn Algorithm} used to validate identification numbers
- * such as bank cards and IMEI numbers.
+ * Returns an Observable that emits a boolean value.
  *
- * @category Boolean Validation
+ * The source should emit a `string` or `number` that can be checked with the
+ * {@link https://en.wikipedia.org/wiki/Luhn_algorithm|Luhn Algorithm} used to validate identification numbers such as
+ * bank cards and IMEI numbers.
+ *
+ * @category Validation
+ *
+ * @typeParam T `string` or `number` value to do the comparison against
  *
  * @example
  * Returns if the value passes the Luhn check.
@@ -24,7 +28,7 @@ import { createLuhnModulus, reverseLuhnNumbers } from '../utils/luhn-check.utils
  * @returns Observable that emits an boolean if the source value passes the Luhn check
  */
 export function luhnCheck<T extends string | number>(): OperatorFunction<T, boolean> {
-  return (source: Observable<T>) =>
+  return (source) =>
     source.pipe(
       map(reverseLuhnNumbers),
       map(createLuhnModulus),

--- a/libs/rxjs/boolean/src/lib/to-boolean.spec.ts
+++ b/libs/rxjs/boolean/src/lib/to-boolean.spec.ts
@@ -18,8 +18,8 @@ describe('toBoolean', () => {
     marbles((m) => {
       const input = m.hot('-a-b-c-|', { a: '', b: 'RxJS', c: 'Ninja' });
       const subs = '^------!';
-      const expected = m.cold('-x-y-z-|', { x: true, y: true, z: false });
-      m.expect(input.pipe(toBoolean((v) => v.length < 5))).toBeObservable(expected);
+      const expected = m.cold('-x-y-z-|', { x: false, y: true, z: false });
+      m.expect(input.pipe(toBoolean((v) => Boolean(v) && v.length < 5))).toBeObservable(expected);
       m.expect(input).toHaveSubscriptions(subs);
     }),
   );

--- a/libs/rxjs/boolean/src/lib/to-boolean.ts
+++ b/libs/rxjs/boolean/src/lib/to-boolean.ts
@@ -2,16 +2,17 @@
  * @packageDocumentation
  * @module Boolean
  */
-import { Observable, OperatorFunction } from 'rxjs';
+import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { PredicateFn } from '../types/boolean';
 
 /**
- * Returns an Observable that emits a boolean value from a source value of any type
+ * Returns an Observable that emits a boolean based on the input value - if no predicate method, the value will be
+ * converted to it's `Boolean` value, otherwise the predicate method is used to convert the boolean
  *
- * @category Boolean Observables
+ * @category Create
  *
- * @typeParam T The value contained in the source Observable
+ * @typeParam T Type of the value from the source Observable
  *
  * @param predicateFn Optional [[PredicateFn]] function to compared the values against
  *
@@ -34,5 +35,5 @@ import { PredicateFn } from '../types/boolean';
  * @returns Observable that emits a boolean value of a source value
  */
 export function toBoolean<T extends unknown>(predicateFn?: PredicateFn<T>): OperatorFunction<T, boolean> {
-  return (source: Observable<T>) => source.pipe(map((value) => (predicateFn ? predicateFn(value) : Boolean(value))));
+  return (source) => source.pipe(map((value) => (predicateFn ? predicateFn(value) : Boolean(value))));
 }


### PR DESCRIPTION
### Added

- `firstFalsy` operator that takes a required predicate and returns the first falsy value to the next operator
- `lastFalsy` operator that takes a required predicate and returns the last falsy value to the next operator
- `filterFalsy` operator that takes a required predicate and returns only values that don't pass the predicate

### Changed

- Documentation updates and reorganising categories
- Internal improvements to `fromBoolean`