### PR TITLE
(minor) Fix bug in set query operator, add isEqualSet

### DIFF
--- a/libs/rxjs/array/CHANGELOG.md
+++ b/libs/rxjs/array/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `isEqualSet` operator that returns a boolean value if the source Array/Set contains the same content as the passed
+  Array/Set
+
+### Fixed
+
+- Improved internals of `isSupersetOf` and `isSubsetOf`
+
 ## [4.0.0] - 2021-01-15
 
 This release contains a few breaking changes and renaming of operators, also all operators now accept a source that is

--- a/libs/rxjs/array/src/index.ts
+++ b/libs/rxjs/array/src/index.ts
@@ -9,7 +9,7 @@
 /* istanbul ignore file */
 export { binarySearch } from './lib/binary-search';
 export { difference } from './lib/difference';
-export { filterDifference } from 'libs/rxjs/array/src/lib/filter-difference';
+export { filterDifference } from './lib/filter-difference';
 export { every } from './lib/every';
 export { fill } from './lib/fill';
 export { filterEvery } from './lib/filter-every';
@@ -25,7 +25,8 @@ export { fromObjectKeys } from './lib/from-object-keys';
 export { fromSet } from './lib/from-set';
 export { indexOf } from './lib/index-of';
 export { intersects } from './lib/intersects';
-export { filterIntersects } from 'libs/rxjs/array/src/lib/filter-intersects';
+export { filterIntersects } from './lib/filter-intersects';
+export { isEqualSet } from './lib/is-equal-set';
 export { isSubsetOf } from './lib/is-subset-of';
 export { isSupersetOf } from './lib/is-superset-of';
 export { join } from './lib/join';

--- a/libs/rxjs/array/src/lib/is-equal-set.spec.ts
+++ b/libs/rxjs/array/src/lib/is-equal-set.spec.ts
@@ -1,0 +1,30 @@
+import { marbles } from 'rxjs-marbles';
+import { isEqualSet } from '@rxjs-ninja/rxjs-array';
+
+describe('isEqualSet', () => {
+  it(
+    'should return an boolean value if the source is an equal set of passed array',
+    marbles((m) => {
+      const input = m.hot('-a-b-c-|', { a: ['a', 'b', 'c'], b: ['a', 'c', 'b', 'a'], c: ['a', 'b', 'z', 'x'] });
+      const subs = '^------!';
+      const expected = m.cold('-x-y-z-|', { x: true, y: true, z: false });
+      m.expect(input.pipe(isEqualSet(['a', 'b', 'c']))).toBeObservable(expected);
+      m.expect(input).toHaveSubscriptions(subs);
+    }),
+  );
+
+  it(
+    'should return an boolean value if the source is an equal set of passed array',
+    marbles((m) => {
+      const input = m.hot('-a-b-c-|', {
+        a: new Set(['a', 'b', 'c']),
+        b: new Set(['a', 'c', 'b', 'a']),
+        c: new Set(['a', 'b', 'z', 'x']),
+      });
+      const subs = '^------!';
+      const expected = m.cold('-x-y-z-|', { x: true, y: true, z: false });
+      m.expect(input.pipe(isEqualSet(['a', 'b', 'c']))).toBeObservable(expected);
+      m.expect(input).toHaveSubscriptions(subs);
+    }),
+  );
+});

--- a/libs/rxjs/array/src/lib/is-equal-set.ts
+++ b/libs/rxjs/array/src/lib/is-equal-set.ts
@@ -1,0 +1,36 @@
+/**
+ * @packageDocumentation
+ * @module Array
+ */
+import { OperatorFunction } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+/**
+ * Returns an Observable that emits a boolean value if the source Observable Array or Set has equal non-duplicate
+ * content of the input Array or Set
+ *
+ * @category Query
+ *
+ * @remarks The source set (A) is equal in content to the input set (B) (`A == B`)
+ *
+ * @typeParam T The input type of the source Array or Set
+ *
+ * @param input The Array or Set to check if the set is equal
+ *
+ * @example Return if the source array is a subset of the input array
+ * ```ts
+ * const input = [ ['a', 'b', 'c'],  ['a', 'c', 'b', 'a'], ['a', 'b', 'z', 'x' ] ];
+ * from(input).pipe(isEqualSet(['a', 'b', 'c'])).subscribe()
+ * ```
+ * Output: `true, true, false`
+ *
+ * @returns Observable that emits a boolean of the source array has equal content to the input array
+ */
+export function isEqualSet<T extends unknown>(input: T[] | Set<T>): OperatorFunction<T[] | Set<T>, boolean> {
+  return (source) =>
+    source.pipe(
+      map((value) => [new Set(input), new Set(value)]),
+      map(([inputValue, value]) => [inputValue, value, inputValue.size == value.size] as [Set<T>, Set<T>, boolean]),
+      map(([inputValue, value, sameSize]) => (sameSize ? [...value].every((e) => [...inputValue].includes(e)) : false)),
+    );
+}

--- a/libs/rxjs/array/src/lib/is-subset-of.ts
+++ b/libs/rxjs/array/src/lib/is-subset-of.ts
@@ -30,13 +30,6 @@ export function isSubsetOf<T extends unknown>(input: T[] | Set<T>): OperatorFunc
   return (source) =>
     source.pipe(
       map((value) => [new Set(input), new Set(value)]),
-      map(([value, set]) => {
-        for (const elem of set) {
-          if (!value.has(elem)) {
-            return false;
-          }
-        }
-        return true;
-      }),
+      map(([inputValue, value]) => [...value].filter((e) => [...inputValue].includes(e)).length === value.size),
     );
 }

--- a/libs/rxjs/array/src/lib/is-superset-of.ts
+++ b/libs/rxjs/array/src/lib/is-superset-of.ts
@@ -30,13 +30,6 @@ export function isSupersetOf<T extends unknown>(input: T[] | Set<T>): OperatorFu
   return (source) =>
     source.pipe(
       map((value) => [new Set(value), new Set(input)]),
-      map(([value, set]) => {
-        for (const elem of set) {
-          if (!value.has(elem)) {
-            return false;
-          }
-        }
-        return true;
-      }),
+      map(([value, inputValue]) => [...inputValue].filter((e) => [...value].includes(e)).length === inputValue.size),
     );
 }


### PR DESCRIPTION
### Added

- `isEqualSet` operator that returns a boolean value if the source Array/Set contains the same content as the passed
  Array/Set

### Fixed

- Improved internals of `isSupersetOf` and `isSubsetOf`