### PR TITLE
(minor) Array method fixes

### DIFF
--- a/libs/rxjs/array/CHANGELOG.md
+++ b/libs/rxjs/array/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- New `ArrayOrSet<T>` type for all inputs and sources in this library
+
+### Changed
+
+- All operators now accept the `ArrayOrSet<T>` as a source, and some also allow as a static or Observable input value
+- Fixed some internals where source was not being piped first, and causing issues with error flow
+
 ## [4.1.0] - 2021-01-15
 
 ### Added

--- a/libs/rxjs/array/CHANGELOG.md
+++ b/libs/rxjs/array/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+Some internal refactoring, however there should be no breaking changes from `4.1.0`
+
 ### Added
 
 - New `ArrayOrSet<T>` type for all inputs and sources in this library

--- a/libs/rxjs/array/src/index.ts
+++ b/libs/rxjs/array/src/index.ts
@@ -39,3 +39,4 @@ export { sortMap } from './lib/sort-map';
 export { toSet } from './lib/to-set';
 
 export { BinarySearchResult } from './types/binary-search';
+export { ArrayOrSet } from './types/array-set';

--- a/libs/rxjs/array/src/lib/binary-search.ts
+++ b/libs/rxjs/array/src/lib/binary-search.ts
@@ -2,12 +2,13 @@
  * @packageDocumentation
  * @module Array
  */
-import { Observable, OperatorFunction } from 'rxjs';
+import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { binarySearcher } from '../utils/search';
 import { defaultSortFn } from '../utils/sort';
 import { BinarySearchResult } from '../types/binary-search';
 import { SortFn } from '../types/generic-methods';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits a [[BinarySearchResult]]. It take a source array and runs a [[SortFn]] over it.
@@ -79,10 +80,10 @@ export function binarySearch<T extends unknown, K extends T | unknown>(
   searchValue: T,
   sortFn?: SortFn<K>,
   property?: string | number,
-): OperatorFunction<K[] | Set<K>, BinarySearchResult<T, K>> {
-  return (source: Observable<K[] | Set<K>>) =>
+): OperatorFunction<ArrayOrSet<K>, BinarySearchResult<T, K>> {
+  return (source) =>
     source.pipe(
-      map<K[] | Set<K>, [K[], K[]]>((accArray) => [[...accArray], [...accArray].sort(sortFn || defaultSortFn)]),
+      map<ArrayOrSet<K>, [K[], K[]]>((accArray) => [[...accArray], [...accArray].sort(sortFn || defaultSortFn)]),
       map(([searchArray, sortedArray]) => [
         binarySearcher(searchValue, sortedArray, property),
         searchValue,

--- a/libs/rxjs/array/src/lib/difference.spec.ts
+++ b/libs/rxjs/array/src/lib/difference.spec.ts
@@ -30,7 +30,7 @@ describe('difference', () => {
   );
 
   it(
-    'should return an array of the differences between the observable source and the difference of strings',
+    'should return an array of the differences between the source and the observable difference of strings',
     marbles((m) => {
       const input = m.hot('-a-b-c-|', {
         a: ['a', 'b', 'c', 'b'],

--- a/libs/rxjs/array/src/lib/difference.ts
+++ b/libs/rxjs/array/src/lib/difference.ts
@@ -3,7 +3,8 @@
  * @module Array
  */
 import { isObservable, Observable, ObservableInput, of, OperatorFunction } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { map, withLatestFrom } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable Array containing unique values that are not in the provided input Array or Set
@@ -35,17 +36,12 @@ import { map, switchMap } from 'rxjs/operators';
  * @returns An Observable that emits an Array containing a subset of the source value
  */
 export function difference<T extends unknown>(
-  input: T[] | Set<T> | ObservableInput<T[] | Set<T>>,
-): OperatorFunction<T[] | Set<T>, T[]> {
+  input: ArrayOrSet<T> | ObservableInput<ArrayOrSet<T>>,
+): OperatorFunction<ArrayOrSet<T>, T[]> {
   return (source) =>
-    ((isObservable(input) ? input : of(input)) as Observable<T[] | Set<T>>).pipe(
-      map((val) => new Set(val)),
-      switchMap((inputValue: Set<T>) =>
-        source.pipe(
-          map((value) => {
-            return [...new Set<T>(value)].filter((x) => !inputValue.has(x));
-          }),
-        ),
-      ),
+    source.pipe(
+      withLatestFrom((isObservable(input) ? input : of(input)) as Observable<ArrayOrSet<T>>),
+      map(([value, inputValue]) => [new Set(value), new Set(inputValue)]),
+      map(([value, inputValue]) => [...value].filter((x) => !inputValue.has(x))),
     );
 }

--- a/libs/rxjs/array/src/lib/every.ts
+++ b/libs/rxjs/array/src/lib/every.ts
@@ -6,6 +6,7 @@
 import { PredicateFn } from '../types/generic-methods';
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits a boolean when all values in the source array return truthy using Array.every
@@ -42,11 +43,11 @@ import { map } from 'rxjs/operators';
  *
  * @returns An Observable that emits a boolean when all values in source array return truthy
  */
-export function every<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<T[], boolean> {
+export function every<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<ArrayOrSet<T>, boolean> {
   return (source) =>
     source.pipe(
       map((value) =>
-        value.every((v) => {
+        [...value].every((v) => {
           if (predicate && typeof v === 'number') {
             return predicate(v);
           }

--- a/libs/rxjs/array/src/lib/fill.ts
+++ b/libs/rxjs/array/src/lib/fill.ts
@@ -3,11 +3,13 @@
  * @module Array
  */
 
-import { Observable, OperatorFunction } from 'rxjs';
+import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
- * Returns an Observable array of values filled with Array.fill. Using the source array length, some or all the values are replaced with the `fillWith` parameter.
+ * Returns an Observable array of values filled with Array.fill. Using the source array length, some or all the values
+ * are replaced with the `fillWith` parameter.
  *
  * @category Modify
  *
@@ -42,13 +44,13 @@ import { map } from 'rxjs/operators';
  * ```
  * Output: `'The', 'Cake', 'CAKE!', 'CAKE!', 'lie'`
  *
- * @returns An Observable that emits an array of values where some or all of the source array values are replaced with the `fillValue`
+ * @returns An Observable that emits an array of values where some or all of the source array values are replaced with
+ *   the `fillValue`
  */
 export function fill<T extends unknown, K extends T | unknown>(
   fillWith: K,
   start = 0,
   fillTo?: number,
-): OperatorFunction<T[], K[]> {
-  return (source: Observable<T[]>) =>
-    source.pipe(map((value: T[]) => value.fill(fillWith as never, start, fillTo) as K[]));
+): OperatorFunction<ArrayOrSet<T>, K[]> {
+  return (source) => source.pipe(map((value) => [...value].fill(fillWith as never, start, fillTo) as K[]));
 }

--- a/libs/rxjs/array/src/lib/filter-difference.ts
+++ b/libs/rxjs/array/src/lib/filter-difference.ts
@@ -4,7 +4,7 @@
  */
 import { isObservable, Observable, ObservableInput, of, OperatorFunction } from 'rxjs';
 import { map, withLatestFrom } from 'rxjs/operators';
-import { ArrayOrSet } from 'libs/rxjs/array/src/types/array-set';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable Array containing filtered values that are not in the provided input Array or Set

--- a/libs/rxjs/array/src/lib/filter-every.ts
+++ b/libs/rxjs/array/src/lib/filter-every.ts
@@ -6,6 +6,7 @@
 import { PredicateFn } from '../types/generic-methods';
 import { OperatorFunction } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits an array when all values in the source array return truthy using Array.every
@@ -44,10 +45,10 @@ import { filter, map } from 'rxjs/operators';
  *
  * @returns An Observable that emits a boolean when all values in source array return truthy with the [[PredicateFn]]
  */
-export function filterEvery<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<T[] | Set<T>, T[]> {
+export function filterEvery<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<ArrayOrSet<T>, T[]> {
   return (source) =>
     source.pipe(
-      map((value) => [...value]),
+      map((value) => [...value]), // Filter requires value to be mapped first to an array
       filter((value) =>
         value.every((v) => {
           if (predicate && typeof v === 'number') {

--- a/libs/rxjs/array/src/lib/filter-intersects.ts
+++ b/libs/rxjs/array/src/lib/filter-intersects.ts
@@ -3,7 +3,8 @@
  * @module Array
  */
 import { isObservable, Observable, ObservableInput, of, OperatorFunction } from 'rxjs';
-import { map, switchMap } from 'rxjs/operators';
+import { map, withLatestFrom } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable Array containing filtered values that are in both the source in the provided input Array or Set
@@ -35,16 +36,12 @@ import { map, switchMap } from 'rxjs/operators';
  * @returns An Observable that emits an Array of the intersection of input and source arrays.
  */
 export function filterIntersects<T extends unknown>(
-  input: T[] | Set<T> | ObservableInput<T[] | Set<T>>,
-): OperatorFunction<T[] | Set<T>, T[]> {
+  input: ArrayOrSet<T> | ObservableInput<ArrayOrSet<T>>,
+): OperatorFunction<ArrayOrSet<T>, T[]> {
   return (source) =>
-    ((isObservable(input) ? input : of(input)) as Observable<T[] | Set<T>>).pipe(
-      map((value) => new Set(value)),
-      switchMap((inputValue) => {
-        return source.pipe(
-          map((value) => [...value]),
-          map((value) => value.filter((v) => inputValue.has(v))),
-        );
-      }),
+    source.pipe(
+      withLatestFrom((isObservable(input) ? input : of(input)) as Observable<ArrayOrSet<T>>),
+      map<[ArrayOrSet<T>, ArrayOrSet<T>], [T[], Set<T>]>(([value, inputValue]) => [[...value], new Set(inputValue)]),
+      map(([value, inputValue]) => value.filter((x) => inputValue.has(x))),
     );
 }

--- a/libs/rxjs/array/src/lib/filter-some.ts
+++ b/libs/rxjs/array/src/lib/filter-some.ts
@@ -5,6 +5,7 @@
 import { PredicateFn } from '../types/generic-methods';
 import { OperatorFunction } from 'rxjs';
 import { filter, map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits an array when one of the values in the source array return truthy using Array.some
@@ -43,10 +44,10 @@ import { filter, map } from 'rxjs/operators';
  *
  * @returns An Observable that emits a boolean when all values in source array return truthy with the [[PredicateFn]]
  */
-export function filterSome<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<T[] | Set<T>, T[]> {
+export function filterSome<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<ArrayOrSet<T>, T[]> {
   return (source) =>
     source.pipe(
-      map((value) => [...value]),
+      map((value) => [...value]), // Filter requires value to be mapped first to an array
       filter((value) =>
         value.some((v) => {
           if (predicate && typeof v === 'number') {

--- a/libs/rxjs/array/src/lib/find-all.ts
+++ b/libs/rxjs/array/src/lib/find-all.ts
@@ -6,6 +6,7 @@
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { PredicateFn } from '../types/generic-methods';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable array of truthy values from a source array
@@ -32,11 +33,11 @@ import { PredicateFn } from '../types/generic-methods';
  *
  * @returns An Observable that emits an array containing all truthy values from a source array
  */
-export function findAll<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<T[] | Set<T>, T[]> {
+export function findAll<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<ArrayOrSet<T>, T[]> {
   return (source) =>
     source.pipe(
-      map(([...value]) =>
-        value.filter((v) => {
+      map((value) =>
+        [...value].filter((v) => {
           if (predicate && typeof v === 'number') {
             return predicate(v);
           }

--- a/libs/rxjs/array/src/lib/find-index.ts
+++ b/libs/rxjs/array/src/lib/find-index.ts
@@ -6,6 +6,7 @@
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { PredicateFn } from '../types/generic-methods';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable number which is the index of the first value found in an array using Array.findIndex
@@ -34,11 +35,11 @@ import { PredicateFn } from '../types/generic-methods';
  *
  * @returns An Observable that emits a number value, the index of first value where [[PredicateFn]] is true
  */
-export function findIndex<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<T[] | Set<T>, number> {
+export function findIndex<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<ArrayOrSet<T>, number> {
   return (source) =>
     source.pipe(
-      map(([...value]) =>
-        value.findIndex((v) => {
+      map((value) =>
+        [...value].findIndex((v) => {
           if (predicate && typeof v === 'number') {
             return predicate(v);
           }

--- a/libs/rxjs/array/src/lib/find-last.ts
+++ b/libs/rxjs/array/src/lib/find-last.ts
@@ -6,7 +6,7 @@
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { PredicateFn } from '../types/generic-methods';
-import { ArrayOrSet } from 'libs/rxjs/array/src/types/array-set';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable value of the last truthy value found in a source array, or `undefined` using Array.find

--- a/libs/rxjs/array/src/lib/find-last.ts
+++ b/libs/rxjs/array/src/lib/find-last.ts
@@ -6,6 +6,7 @@
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { PredicateFn } from '../types/generic-methods';
+import { ArrayOrSet } from 'libs/rxjs/array/src/types/array-set';
 
 /**
  * Returns an Observable value of the last truthy value found in a source array, or `undefined` using Array.find
@@ -34,12 +35,13 @@ import { PredicateFn } from '../types/generic-methods';
  *
  * @returns An Observable that emits the last found value from the array, or `undefined`
  */
-export function findLast<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<T[] | Set<T>, T | undefined> {
+export function findLast<T extends unknown>(
+  predicate?: PredicateFn<T>,
+): OperatorFunction<ArrayOrSet<T>, T | undefined> {
   return (source) =>
     source.pipe(
-      map((value) => [...value].reverse()),
       map((value) =>
-        value.find((v) => {
+        [...value].reverse().find((v) => {
           if (predicate && typeof v === 'number') {
             return predicate(v);
           }

--- a/libs/rxjs/array/src/lib/find.ts
+++ b/libs/rxjs/array/src/lib/find.ts
@@ -6,7 +6,7 @@
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { PredicateFn } from '../types/generic-methods';
-import { ArrayOrSet } from 'libs/rxjs/array/src/types/array-set';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable value of the first truthy value found in a source array, or `undefined` using Array.find

--- a/libs/rxjs/array/src/lib/find.ts
+++ b/libs/rxjs/array/src/lib/find.ts
@@ -6,6 +6,7 @@
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { PredicateFn } from '../types/generic-methods';
+import { ArrayOrSet } from 'libs/rxjs/array/src/types/array-set';
 
 /**
  * Returns an Observable value of the first truthy value found in a source array, or `undefined` using Array.find
@@ -34,11 +35,11 @@ import { PredicateFn } from '../types/generic-methods';
  *
  * @returns An Observable that emits the first found value from the array, or `undefined`
  */
-export function find<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<T[] | Set<T>, T | undefined> {
+export function find<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<ArrayOrSet<T>, T | undefined> {
   return (source) =>
     source.pipe(
-      map(([...value]) =>
-        value.find((v) => {
+      map((value) =>
+        [...value].find((v) => {
           if (predicate && typeof v === 'number') {
             return predicate(v);
           }

--- a/libs/rxjs/array/src/lib/flip-array.ts
+++ b/libs/rxjs/array/src/lib/flip-array.ts
@@ -2,11 +2,13 @@
  * @packageDocumentation
  * @module Array
  */
-import { MonoTypeOperatorFunction, Observable } from 'rxjs';
+import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
- * Returns an Observable array where the source array contains boolean values, and flips the value to the opposite boolean.
+ * Returns an Observable array where the source array contains boolean values, and flips the value to the opposite
+ * boolean.
  *
  * @category Modify
  *
@@ -20,6 +22,6 @@ import { map } from 'rxjs/operators';
  *
  * @returns Observable array of boolean values that are flipped from their original value
  */
-export function flipArray(): MonoTypeOperatorFunction<boolean[]> {
-  return (source: Observable<boolean[]>) => source.pipe(map((value) => value.map((v) => !v)));
+export function flipArray(): OperatorFunction<ArrayOrSet<boolean>, boolean[]> {
+  return (source) => source.pipe(map((value) => [...value].map((v) => !v)));
 }

--- a/libs/rxjs/array/src/lib/index-of.ts
+++ b/libs/rxjs/array/src/lib/index-of.ts
@@ -5,6 +5,8 @@
 
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
+import { isArrayOrSet } from '../utils/array-set';
 
 /**
  * Returns an Observable Number if the input is a single value, or Array of numbers in the input is an Array.
@@ -44,15 +46,15 @@ import { map } from 'rxjs/operators';
  * @returns Observable number or array of numbers containing the index of the first found value
  */
 export function indexOf<T extends unknown>(
-  input: T | T[] | Set<T>,
+  input: T | ArrayOrSet<T>,
   startIndex = 0,
-): OperatorFunction<T[] | Set<T>, number | number[]> {
+): OperatorFunction<ArrayOrSet<T>, number | number[]> {
   return (source) =>
     source.pipe(
-      map(([...value]) =>
-        Array.isArray(input)
-          ? input.map((inputVal) => value.indexOf(inputVal, startIndex))
-          : value.indexOf(input as T, startIndex),
+      map((value) =>
+        isArrayOrSet(input)
+          ? input.map((inputVal) => [...value].indexOf(inputVal, startIndex))
+          : [...value].indexOf(input as T, startIndex),
       ),
     );
 }

--- a/libs/rxjs/array/src/lib/is-equal-set.ts
+++ b/libs/rxjs/array/src/lib/is-equal-set.ts
@@ -4,6 +4,7 @@
  */
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits a boolean value if the source Observable Array or Set has equal non-duplicate
@@ -26,7 +27,7 @@ import { map } from 'rxjs/operators';
  *
  * @returns Observable that emits a boolean of the source array has equal content to the input array
  */
-export function isEqualSet<T extends unknown>(input: T[] | Set<T>): OperatorFunction<T[] | Set<T>, boolean> {
+export function isEqualSet<T extends unknown>(input: ArrayOrSet<T>): OperatorFunction<ArrayOrSet<T>, boolean> {
   return (source) =>
     source.pipe(
       map((value) => [new Set(input), new Set(value)]),

--- a/libs/rxjs/array/src/lib/is-subset-of.ts
+++ b/libs/rxjs/array/src/lib/is-subset-of.ts
@@ -4,6 +4,7 @@
  */
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits a boolean value if the source Observable Array or Set is a subset of
@@ -26,7 +27,7 @@ import { map } from 'rxjs/operators';
  *
  * @returns Observable that emits a boolean of the source array being a subset of the input array
  */
-export function isSubsetOf<T extends unknown>(input: T[] | Set<T>): OperatorFunction<T[] | Set<T>, boolean> {
+export function isSubsetOf<T extends unknown>(input: ArrayOrSet<T>): OperatorFunction<ArrayOrSet<T>, boolean> {
   return (source) =>
     source.pipe(
       map((value) => [new Set(input), new Set(value)]),

--- a/libs/rxjs/array/src/lib/is-superset-of.ts
+++ b/libs/rxjs/array/src/lib/is-superset-of.ts
@@ -4,6 +4,7 @@
  */
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits a boolean value if the source Observable Array or Set is a superset of
@@ -26,7 +27,7 @@ import { map } from 'rxjs/operators';
  *
  * @returns Observable that emits a boolean of the source array being a superset of the input array
  */
-export function isSupersetOf<T extends unknown>(input: T[] | Set<T>): OperatorFunction<T[] | Set<T>, boolean> {
+export function isSupersetOf<T extends unknown>(input: ArrayOrSet<T>): OperatorFunction<ArrayOrSet<T>, boolean> {
   return (source) =>
     source.pipe(
       map((value) => [new Set(value), new Set(input)]),

--- a/libs/rxjs/array/src/lib/join.ts
+++ b/libs/rxjs/array/src/lib/join.ts
@@ -4,6 +4,7 @@
  */
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits a joining the values of the Array or Set using the `separator` character using
@@ -33,6 +34,6 @@ import { map } from 'rxjs/operators';
  *
  * @returns Observable string from the joined values in the source array
  */
-export function join<T extends unknown>(separator = ' '): OperatorFunction<T[] | Set<T>, string> {
+export function join<T extends unknown>(separator = ' '): OperatorFunction<ArrayOrSet<T>, string> {
   return (source) => source.pipe(map((value) => [...value].join(separator)));
 }

--- a/libs/rxjs/array/src/lib/last-index-of.ts
+++ b/libs/rxjs/array/src/lib/last-index-of.ts
@@ -4,6 +4,8 @@
  */
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
+import { isArrayOrSet } from '../utils/array-set';
 
 /**
  * Returns an Observable number or array of numbers. These are the index numbers of first truthy value in the source
@@ -51,16 +53,16 @@ import { map } from 'rxjs/operators';
  * @returns Observable number or array of numbers containing the index of the last found value
  */
 export function lastIndexOf<T extends unknown>(
-  input: T | T[] | Set<T>,
+  input: T | ArrayOrSet<T>,
   fromIndex?: number,
-): OperatorFunction<T[] | Set<T>, number | number[]> {
+): OperatorFunction<ArrayOrSet<T>, number | number[]> {
   return (source) =>
     source.pipe(
       map(([...value]) => {
         fromIndex = fromIndex || value.length - 1;
-        return Array.isArray(input) || input instanceof Set
+        return isArrayOrSet(input)
           ? [...input].map((inputVal) => value.lastIndexOf(inputVal, fromIndex))
-          : value.lastIndexOf(input, fromIndex);
+          : value.lastIndexOf(input as T, fromIndex);
       }),
     );
 }

--- a/libs/rxjs/array/src/lib/reverse.ts
+++ b/libs/rxjs/array/src/lib/reverse.ts
@@ -5,6 +5,7 @@
 
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits array taking the source and running the result of Array.reverse
@@ -23,6 +24,6 @@ import { map } from 'rxjs/operators';
  *
  * @returns Observable that emits an array which is reversed from the source array
  */
-export function reverse<T extends unknown>(): OperatorFunction<T[] | Set<T>, T[]> {
+export function reverse<T extends unknown>(): OperatorFunction<ArrayOrSet<T>, T[]> {
   return (source) => source.pipe(map((value) => [...value].reverse()));
 }

--- a/libs/rxjs/array/src/lib/shuffle.ts
+++ b/libs/rxjs/array/src/lib/shuffle.ts
@@ -4,6 +4,7 @@
  */
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits an array taking a source array and randomly shuffling the elements
@@ -22,7 +23,7 @@ import { map } from 'rxjs/operators';
  *
  * @returns Observable that emits an array of values shuffled from the source array
  */
-export function shuffle<T extends unknown>(): OperatorFunction<T[] | Set<T>, T[]> {
+export function shuffle<T extends unknown>(): OperatorFunction<ArrayOrSet<T>, T[]> {
   return (source) =>
     source.pipe(
       map(([...arr]) => {

--- a/libs/rxjs/array/src/lib/some.ts
+++ b/libs/rxjs/array/src/lib/some.ts
@@ -6,6 +6,7 @@
 import { PredicateFn } from '../types/generic-methods';
 import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits a boolean when all values in the source Array or Set return truthy using Array.some
@@ -36,11 +37,11 @@ import { map } from 'rxjs/operators';
  *
  * @returns An Observable that emits a boolean when all values in source array return truthy
  */
-export function some<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<T[] | Set<T>, boolean> {
+export function some<T extends unknown>(predicate?: PredicateFn<T>): OperatorFunction<ArrayOrSet<T>, boolean> {
   return (source) =>
     source.pipe(
-      map(([...value]) =>
-        value.some((v) => {
+      map((value) =>
+        [...value].some((v) => {
           if (predicate && typeof v === 'number') {
             return predicate(v);
           }

--- a/libs/rxjs/array/src/lib/sort-map.ts
+++ b/libs/rxjs/array/src/lib/sort-map.ts
@@ -6,6 +6,7 @@ import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { defaultSortFn } from '../utils/sort';
 import { MapFn, SortFn } from '../types/generic-methods';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits an array of sorted mapped values from a source array where values are mapped to
@@ -51,7 +52,7 @@ import { MapFn, SortFn } from '../types/generic-methods';
 export function sortMap<T extends unknown, K extends T | unknown>(
   mapFn: MapFn<T, K>,
   sortFn?: SortFn<T>,
-): OperatorFunction<T[] | Set<T>, K[]> {
+): OperatorFunction<ArrayOrSet<T>, K[]> {
   return (source) =>
     source.pipe(
       map((value) => [...value].sort(sortFn || defaultSortFn)),

--- a/libs/rxjs/array/src/lib/sort.ts
+++ b/libs/rxjs/array/src/lib/sort.ts
@@ -6,6 +6,7 @@ import { OperatorFunction } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { defaultSortFn } from '../utils/sort';
 import { SortFn } from '../types/generic-methods';
+import { ArrayOrSet } from '../types/array-set';
 
 /**
  * Returns an Observable that emits an array of sorted values from the source Array or Set using the [[SortFn]]
@@ -42,6 +43,6 @@ import { SortFn } from '../types/generic-methods';
  *
  * @returns Observable array of values from source array sorted via [[SortFn]]
  */
-export function sort<T extends unknown>(sortFn?: SortFn<T>): OperatorFunction<T[] | Set<T>, T[]> {
+export function sort<T extends unknown>(sortFn?: SortFn<T>): OperatorFunction<ArrayOrSet<T>, T[]> {
   return (source) => source.pipe(map((value) => [...value].sort(sortFn || defaultSortFn)));
 }

--- a/libs/rxjs/array/src/types/array-set.ts
+++ b/libs/rxjs/array/src/types/array-set.ts
@@ -1,0 +1,13 @@
+/**
+ * @packageDocumentation
+ * @module Array
+ */
+
+/**
+ * An Array-like interface that is an array of items or a set of items
+ *
+ * @internal
+ *
+ * @typeParam T The type of the value from the input source
+ */
+export type ArrayOrSet<T> = T[] | Set<T>;

--- a/libs/rxjs/array/src/utils/array-set.ts
+++ b/libs/rxjs/array/src/utils/array-set.ts
@@ -1,0 +1,16 @@
+/**
+ * @packageDocumentation
+ * @module Array
+ */
+
+/**
+ * Returns if the input is an array or
+ * @private
+ * @internal
+ * @param input
+ */
+export function isArrayOrSet(input: unknown): input is ArrayLike<unknown> {
+  if (Array.isArray(input)) {
+    return true;
+  } else return input instanceof Set;
+}


### PR DESCRIPTION
Some Array methods were incorrectly piping a different source first, instead of the operator source.  

Fixed internals, added new `ArrayOrSet<T>` type for source values.