### PR TITLE
(minor) New operators for distribution

### DIFF
--- a/libs/rxjs/number/CHANGELOG.md
+++ b/libs/rxjs/number/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- `roundTo` operator that returns a fixed number value to the passed precision value
+- New `Distribution` category for getting a number value from an `Iterable` source like Array or Set
+  - `max` and `min` operators that returns the maximum or minimum number from an `Iterable` source
+  - `mean` and `median` operators that calculate the mean/median value of an `Iterable` source, by default this will round
+    to `3` places but can be passed as a property
+
 ## [5.0.1] - 2021-01-21
 
 ### Changed

--- a/libs/rxjs/number/README.md
+++ b/libs/rxjs/number/README.md
@@ -25,6 +25,21 @@ fromNumber().pipe(take(6), add(1), mod(3)).subscribe();
 // Output: `1, 2, 0, 1, 2, 0`
 ```
 
+### Distribution
+
+Operators for handling the distribution of numbers, these will return a single value from an Iterable of numbers
+
+```ts
+const source$ = from([
+  [1, 2, 3],
+  [10, 15, 8],
+  [5, 10, 100],
+]);
+// Get the Median, Mean, Mix and Max values
+combineLatest([source$.pipe(median()), source$.pipe(mean()), source$.pipe(min()), source$.pipe(max())]).subscribe();
+// Output : [ [ 2, 2, 1, 3 ], [ 15, 11, 8, 15 ], [ 52.5, 38.333, 5, 100 ] ]
+```
+
 ### Filter
 
 Operators for filtering Observable number sources for truthy queries

--- a/libs/rxjs/number/src/index.ts
+++ b/libs/rxjs/number/src/index.ts
@@ -1,6 +1,6 @@
 /**
- * The RxJS Ninja Number module contains operators for working with, and returning number values. The operators allow for
- * filtering, querying, converting to and from String, and mathematical operations.
+ * The RxJS Ninja Number module contains operators for working with, and returning number values. The operators allow
+ * for filtering, querying, converting to and from String, and mathematical operations.
  *
  * @packageDocumentation
  * @module Number
@@ -8,6 +8,7 @@
  */
 /* istanbul ignore file */
 export { add } from './lib/add';
+export { mean, mean as average } from './lib/mean';
 export { div } from './lib/div';
 export { filterInRange } from './lib/filter-in-range';
 export { filterIsFinite } from './lib/filter-is-finite';
@@ -26,6 +27,9 @@ export { isMod } from './lib/is-mod';
 export { isNaN } from './lib/is-nan';
 export { isNotNaN } from './lib/is-not-nan';
 export { isSafeInteger } from './lib/is-safe-integer';
+export { max } from './lib/max';
+export { median } from './lib/median';
+export { min } from './lib/min';
 export { mod } from './lib/mod';
 export { mul } from './lib/mul';
 export { outOfRange } from './lib/out-of-range';
@@ -33,6 +37,7 @@ export { parseFloat } from './lib/parse-float';
 export { parseHex } from './lib/parse-hex';
 export { parseInt } from './lib/parse-int';
 export { pow } from './lib/pow';
+export { roundTo } from './lib/round-to';
 export { sub } from './lib/sub';
 export { toExponential } from './lib/to-exponential';
 export { toFixed } from './lib/to-fixed';

--- a/libs/rxjs/number/src/lib/max.spec.ts
+++ b/libs/rxjs/number/src/lib/max.spec.ts
@@ -1,0 +1,15 @@
+import { marbles } from 'rxjs-marbles/jest';
+import { max } from '@rxjs-ninja/rxjs-number';
+
+describe('max', () => {
+  it(
+    'should return the maximum number in the passed array',
+    marbles((m) => {
+      const input = m.hot('-a-b-c-|', { a: [1, 2, 3], b: [-1, 0, 1], c: [-10, -1, -5] });
+      const subs = '^------!';
+      const expected = m.cold('-x-y-z-|', { x: 3, y: 1, z: -1 });
+      m.expect(input.pipe(max())).toBeObservable(expected);
+      m.expect(input).toHaveSubscriptions(subs);
+    }),
+  );
+});

--- a/libs/rxjs/number/src/lib/max.ts
+++ b/libs/rxjs/number/src/lib/max.ts
@@ -1,0 +1,26 @@
+/**
+ * @packageDocumentation
+ * @module Number
+ */
+import { OperatorFunction } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+/**
+ * Returns an Observable that emits the maximum number value from an Iterable of numbers
+ *
+ * @category Distribution
+ *
+ * @example
+ * Return the max of the source number Array
+ * ```ts
+ * const source$ = from([ [1, 2, 3], [10, 15, 8], [5, 10, 100] ]);
+ *
+ * source$.pipe(max()).subscribe();
+ * ```
+ * Output: `3, 15, 100`
+ *
+ * @returns Observable that emits a number that is the maximum value in the source Iterable
+ */
+export function max(): OperatorFunction<Iterable<number>, number> {
+  return (source) => source.pipe(map((value) => [...value].reduce((a, b) => Math.max(a, b))));
+}

--- a/libs/rxjs/number/src/lib/mean.spec.ts
+++ b/libs/rxjs/number/src/lib/mean.spec.ts
@@ -1,0 +1,15 @@
+import { marbles } from 'rxjs-marbles/jest';
+import { mean } from '@rxjs-ninja/rxjs-number';
+
+describe('mean', () => {
+  it(
+    'should return the mean of numbers in the array',
+    marbles((m) => {
+      const input = m.hot('-a-b-c-|', { a: [1, 2, 3], b: [10, 15, 8], c: [5, 10, 100] });
+      const subs = '^------!';
+      const expected = m.cold('-x-y-z-|', { x: 2, y: 11, z: 38.333 });
+      m.expect(input.pipe(mean())).toBeObservable(expected);
+      m.expect(input).toHaveSubscriptions(subs);
+    }),
+  );
+});

--- a/libs/rxjs/number/src/lib/mean.ts
+++ b/libs/rxjs/number/src/lib/mean.ts
@@ -1,0 +1,34 @@
+/**
+ * @packageDocumentation
+ * @module Number
+ */
+import { OperatorFunction, Subscribable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { roundTo } from './round-to';
+
+/**
+ * Returns an Observable that emits the calculated mean number value from an Iterable of numbers
+ *
+ * @category Distribution
+ *
+ * @param precision Precision to round the result to, default is `3`
+ *
+ * @example
+ * Return the mean of the source number arrays
+ * ```ts
+ * const source$ = from([ [1, 2, 3], [10, 15, 8], [5, 10, 100] ]);
+ *
+ * source$.pipe(mean()).subscribe();
+ * ```
+ * Output: `2, 11, 38.333`
+ *
+ * @returns Observable that emits a number that is the mean of all values in the source Iterable
+ */
+export function mean(precision: Subscribable<number> | number = 3): OperatorFunction<Iterable<number>, number> {
+  return (source) =>
+    source.pipe(
+      map(([...value]) => [value.length, value.reduce((a, b) => (a += b))]),
+      map(([length, value]) => value / length),
+      roundTo(precision),
+    );
+}

--- a/libs/rxjs/number/src/lib/median.spec.ts
+++ b/libs/rxjs/number/src/lib/median.spec.ts
@@ -1,0 +1,15 @@
+import { marbles } from 'rxjs-marbles/jest';
+import { median } from '@rxjs-ninja/rxjs-number';
+
+describe('median', () => {
+  it(
+    'should return the median value of numbers in the array',
+    marbles((m) => {
+      const input = m.hot('-a-b-c-|', { a: [1, 2, 3], b: [10, 15, 8], c: [5, 10, 75, 100] });
+      const subs = '^------!';
+      const expected = m.cold('-x-y-z-|', { x: 2, y: 15, z: 52.5 });
+      m.expect(input.pipe(median())).toBeObservable(expected);
+      m.expect(input).toHaveSubscriptions(subs);
+    }),
+  );
+});

--- a/libs/rxjs/number/src/lib/median.ts
+++ b/libs/rxjs/number/src/lib/median.ts
@@ -1,0 +1,34 @@
+/**
+ * @packageDocumentation
+ * @module Number
+ */
+import { OperatorFunction, Subscribable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { roundTo } from './round-to';
+
+/**
+ * Returns an Observable that emits the median number value from an Iterable of numbers
+ *
+ * @category Distribution
+ *
+ * @example
+ * Return the median of the source number Array
+ * ```ts
+ * const source$ = from([ [1, 2, 3], [10, 15, 8], [5, 10, 100] ]);
+ *
+ * source$.pipe(median()).subscribe();
+ * ```
+ * Output: `2, 15, 52.5`
+ *
+ * @returns Observable that emits a number that is the median value in the source Iterable
+ */
+export function median(precision: Subscribable<number> | number = 3): OperatorFunction<Iterable<number>, number> {
+  return (source) =>
+    source.pipe(
+      map<Iterable<number>, [number[], number]>(([...value]) => [value.sort(), Math.ceil(value.length / 2)]),
+      map<[number[], number], number>(([value, mid]) =>
+        value.length % 2 === 0 ? (value[mid] + value[mid - 1]) / 2 : value[mid - 1],
+      ),
+      roundTo(precision),
+    );
+}

--- a/libs/rxjs/number/src/lib/min.spec.ts
+++ b/libs/rxjs/number/src/lib/min.spec.ts
@@ -1,0 +1,15 @@
+import { marbles } from 'rxjs-marbles/jest';
+import { min } from '@rxjs-ninja/rxjs-number';
+
+describe('min', () => {
+  it(
+    'should return the min number in the passed array',
+    marbles((m) => {
+      const input = m.hot('-a-b-c-|', { a: [1, 2, 3], b: [-1, 0, 1], c: [-10, -1, -5] });
+      const subs = '^------!';
+      const expected = m.cold('-x-y-z-|', { x: 1, y: -1, z: -10 });
+      m.expect(input.pipe(min())).toBeObservable(expected);
+      m.expect(input).toHaveSubscriptions(subs);
+    }),
+  );
+});

--- a/libs/rxjs/number/src/lib/min.ts
+++ b/libs/rxjs/number/src/lib/min.ts
@@ -1,0 +1,26 @@
+/**
+ * @packageDocumentation
+ * @module Number
+ */
+import { OperatorFunction } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+/**
+ * Returns an Observable that emits the minimum number value from an Iterable of numbers
+ *
+ * @category Distribution
+ *
+ * @example
+ * Return the min of the source number Array
+ * ```ts
+ * const source$ = from([ [1, 2, 3], [10, 15, 8], [5, 10, 100] ]);
+ *
+ * source$.pipe(min()).subscribe();
+ * ```
+ * Output: `1, 8, 5`
+ *
+ * @returns Observable that emits a number that is the minimum value in the source Iterable
+ */
+export function min(): OperatorFunction<Iterable<number>, number> {
+  return (source) => source.pipe(map((value) => [...value].reduce((a, b) => Math.min(a, b))));
+}

--- a/libs/rxjs/number/src/lib/round-to.spec.ts
+++ b/libs/rxjs/number/src/lib/round-to.spec.ts
@@ -1,0 +1,39 @@
+import { roundTo } from '@rxjs-ninja/rxjs-number';
+import { marbles } from 'rxjs-marbles/jest';
+import { of } from 'rxjs';
+
+describe('toFixed', () => {
+  it(
+    'should return a string of a number with 2 decimal places',
+    marbles((m) => {
+      const input = m.hot('-a-b-c-d-e-|', { a: 1.1234, b: 1.1287, c: 1, d: 2.3, e: 3.14 });
+      const subs = '^----------!';
+      const expected = m.cold('-w-v-x-y-z-|', {
+        w: 1.12,
+        v: 1.13,
+        x: 1,
+        y: 2.3,
+        z: 3.14,
+      });
+      m.expect(input.pipe(roundTo(2))).toBeObservable(expected);
+      m.expect(input).toHaveSubscriptions(subs);
+    }),
+  );
+
+  it(
+    'should return a string of a Observable number with 2 decimal places',
+    marbles((m) => {
+      const input = m.hot('-a-b-c-d-e-|', { a: 1.1234, b: 1.1287, c: 1, d: 2.3, e: 3.14 });
+      const subs = '^----------!';
+      const expected = m.cold('-w-v-x-y-z-|', {
+        w: 1.12,
+        v: 1.13,
+        x: 1,
+        y: 2.3,
+        z: 3.14,
+      });
+      m.expect(input.pipe(roundTo(of(2)))).toBeObservable(expected);
+      m.expect(input).toHaveSubscriptions(subs);
+    }),
+  );
+});

--- a/libs/rxjs/number/src/lib/round-to.ts
+++ b/libs/rxjs/number/src/lib/round-to.ts
@@ -1,0 +1,35 @@
+/**
+ * @packageDocumentation
+ * @module Number
+ */
+import { MonoTypeOperatorFunction, Subscribable } from 'rxjs';
+import { map, withLatestFrom } from 'rxjs/operators';
+import { createOrReturnObservable } from '../utils/internal';
+
+/**
+ * Returns an Observable that emits a number value rounded to the number of digits passed
+ *
+ * @category Modify
+ *
+ * @param precision Maximum number of digits to round the number to
+ *
+ * @example Return a number to fixed position of `2`
+ * ```ts
+ * const input = [1.8372, 2.12353, 3.14, 42.2];
+ * from(input).pipe(roundTo(2)).subscribe();
+ * ```
+ * Output: `1.84, 2.12, 3.14, 42.2`
+ *
+ * @returns Observable that emits a number number to a fixed decimal value
+ */
+export function roundTo(precision: Subscribable<number> | number): MonoTypeOperatorFunction<number> {
+  const precision$ = createOrReturnObservable(precision);
+  return (source) =>
+    source.pipe(
+      withLatestFrom(precision$),
+      map(([value, precisionValue]) => {
+        const factor = 10 ** precisionValue;
+        return Math.round(value * factor) / factor;
+      }),
+    );
+}


### PR DESCRIPTION
### Added

- `roundTo` operator that returns a fixed number value to the passed precision value
- New `Distribution` category for getting a number value from an `Iterable` source like Array or Set
  - `max` and `min` operators that returns the maximum or minimum number from an `Iterable` source
  - `mean` and `median` operators that calculate the mean/median value of an `Iterable` source, by default this will round
    to `3` places but can be passed as a property