### PR TITLE
(patch) Fix issues around UMD exports of rxjs namespaces

### DIFF
--- a/libs/rxjs/array/CHANGELOG.md
+++ b/libs/rxjs/array/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Update to internal build configuration for UMD compile `rxjs` and `rxjs/operators` now correctly set as `rxjs`
+  and `rxjs.operators` for globals
+
 ## [6.0.1] - 2021-01-21
 
 ### Changed

--- a/libs/rxjs/boolean/CHANGELOG.md
+++ b/libs/rxjs/boolean/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Update to internal build configuration for UMD compile `rxjs` and `rxjs/operators` now correctly set as `rxjs`
+  and `rxjs.operators` for globals
+
 ## [4.0.1] - 2021-01-21
 
 ### Changed

--- a/libs/rxjs/number/CHANGELOG.md
+++ b/libs/rxjs/number/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Update to internal build configuration for UMD compile `rxjs` and `rxjs/operators` now correctly set as `rxjs`
+  and `rxjs.operators` for globals
+
 ## [5.1.0] - 2021-01-25
 
 ### Added

--- a/libs/rxjs/random/CHANGELOG.md
+++ b/libs/rxjs/random/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Update to internal build configuration for UMD compile `rxjs` and `rxjs/operators` now correctly set as `rxjs`
+  and `rxjs.operators` for globals
+
 ## [2.1.1] - 2021-01-21
 
 ### Changed

--- a/libs/rxjs/string/CHANGELOG.md
+++ b/libs/rxjs/string/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Update to internal build configuration for UMD compile `rxjs` and `rxjs/operators` now correctly set as `rxjs`
+  and `rxjs.operators` for globals
+
 ## [5.0.1] - 2021-01-21
 
 ### Changed

--- a/libs/rxjs/string/src/lib/from-char-code.ts
+++ b/libs/rxjs/string/src/lib/from-char-code.ts
@@ -4,8 +4,8 @@
  */
 import { Observable, Subscribable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { isIterable } from 'rxjs/internal-compatibility';
 import { createOrReturnObservable } from '../utils/internal';
+import { isArrayOrSet } from '../utils/array-set';
 
 /**
  * Returns an Observable that emits a string made from character codes using String.fromCharCode
@@ -38,7 +38,7 @@ export function fromCharCode(
   input: Subscribable<Iterable<number> | number> | Iterable<number> | number,
 ): Observable<string> {
   return createOrReturnObservable(input).pipe(
-    map<Iterable<number> | number, number[]>((value) => (isIterable(value) ? [...value] : [value])),
+    map<Iterable<number> | number, number[]>((value) => (isArrayOrSet(value) ? [...value] : [value])),
     map((value) => String.fromCharCode(...value)),
   );
 }

--- a/libs/rxjs/string/src/utils/array-set.ts
+++ b/libs/rxjs/string/src/utils/array-set.ts
@@ -1,0 +1,16 @@
+/**
+ * @packageDocumentation
+ * @module String
+ */
+
+/**
+ * Returns if the input is an array or
+ * @private
+ * @internal
+ * @param input
+ */
+export function isArrayOrSet<T extends unknown>(input: unknown): input is Iterable<T> {
+  if (Array.isArray(input)) {
+    return true;
+  } else return input instanceof Set;
+}

--- a/libs/rxjs/utility/CHANGELOG.md
+++ b/libs/rxjs/utility/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Update to internal build configuration for UMD compile `rxjs` and `rxjs/operators` now correctly set as `rxjs`
+  and `rxjs.operators` for globals
+
 ### [4.3.0] - 2021-01-25
 
 ### Added

--- a/workspace.json
+++ b/workspace.json
@@ -24,6 +24,16 @@
         "build": {
           "builder": "@nrwl/web:package",
           "options": {
+            "globals": [
+              {
+                "moduleId": "rxjs",
+                "global": "rxjs"
+              },
+              {
+                "moduleId": "rxjs/operators",
+                "global": "rxjs.operators"
+              }
+            ],
             "outputPath": "dist/libs/rxjs/array",
             "tsConfig": "libs/rxjs/array/tsconfig.lib.json",
             "project": "libs/rxjs/array/package.json",
@@ -70,6 +80,16 @@
         "build": {
           "builder": "@nrwl/web:package",
           "options": {
+            "globals": [
+              {
+                "moduleId": "rxjs",
+                "global": "rxjs"
+              },
+              {
+                "moduleId": "rxjs/operators",
+                "global": "rxjs.operators"
+              }
+            ],
             "outputPath": "dist/libs/rxjs/boolean",
             "tsConfig": "libs/rxjs/boolean/tsconfig.lib.json",
             "project": "libs/rxjs/boolean/package.json",
@@ -116,6 +136,16 @@
         "build": {
           "builder": "@nrwl/web:package",
           "options": {
+            "globals": [
+              {
+                "moduleId": "rxjs",
+                "global": "rxjs"
+              },
+              {
+                "moduleId": "rxjs/operators",
+                "global": "rxjs.operators"
+              }
+            ],
             "outputPath": "dist/libs/rxjs/number",
             "tsConfig": "libs/rxjs/number/tsconfig.lib.json",
             "project": "libs/rxjs/number/package.json",
@@ -162,6 +192,16 @@
         "build": {
           "builder": "@nrwl/web:package",
           "options": {
+            "globals": [
+              {
+                "moduleId": "rxjs",
+                "global": "rxjs"
+              },
+              {
+                "moduleId": "rxjs/operators",
+                "global": "rxjs.operators"
+              }
+            ],
             "outputPath": "dist/libs/rxjs/random",
             "tsConfig": "libs/rxjs/random/tsconfig.lib.json",
             "project": "libs/rxjs/random/package.json",
@@ -208,6 +248,16 @@
         "build": {
           "builder": "@nrwl/web:package",
           "options": {
+            "globals": [
+              {
+                "moduleId": "rxjs",
+                "global": "rxjs"
+              },
+              {
+                "moduleId": "rxjs/operators",
+                "global": "rxjs.operators"
+              }
+            ],
             "outputPath": "dist/libs/rxjs/string",
             "tsConfig": "libs/rxjs/string/tsconfig.lib.json",
             "project": "libs/rxjs/string/package.json",
@@ -254,6 +304,16 @@
         "build": {
           "builder": "@nrwl/web:package",
           "options": {
+            "globals": [
+              {
+                "moduleId": "rxjs",
+                "global": "rxjs"
+              },
+              {
+                "moduleId": "rxjs/operators",
+                "global": "rxjs.operators"
+              }
+            ],
             "outputPath": "dist/libs/rxjs/utility",
             "tsConfig": "libs/rxjs/utility/tsconfig.lib.json",
             "project": "libs/rxjs/utility/package.json",


### PR DESCRIPTION
This PR fixes the UMD compile so `rxjs` and `rxjs/operators` are available on the correct global namespace.